### PR TITLE
Update to work with Selenium versions >= 4.10.0

### DIFF
--- a/seleniumprint/drivers/chrome_pdf_driver.py
+++ b/seleniumprint/drivers/chrome_pdf_driver.py
@@ -2,7 +2,7 @@ import base64
 from typing import Union
 import json
 from selenium import webdriver
-from selenium.webdriver.chrome.service import DEFAULT_EXECUTABLE_PATH
+from selenium.webdriver.chrome.service import Service
 from .i_selenium_pdf_driver import ISeleniumPDFDriver
 
 class ChromePDFDriver(ISeleniumPDFDriver):
@@ -35,9 +35,9 @@ class ChromePDFDriver(ISeleniumPDFDriver):
         chrome_options.add_argument("--kiosk-printing")
         if not kwargs.get("disable_headless") is True:
             chrome_options.add_argument("--headless")
-        chrome_driver_path = kwargs.get("chrome_driver_path") or DEFAULT_EXECUTABLE_PATH
+        chrome_driver_path = kwargs.get("chrome_driver_path")
         self.driver = webdriver.Chrome(
-            executable_path=chrome_driver_path, options=chrome_options
+            options=chrome_options, service=Service(executable_path=chrome_driver_path)
         )
 
     def load_page(self, url, *args, **kwargs):


### PR DESCRIPTION
Specifying `executable_path` in the Chrome webdriver constructor [was removed in Selenium 4.10.0](https://github.com/SeleniumHQ/selenium/commit/9f5801c82fb3be3d5850707c46c3f8176e3ccd8e#diff-5a60156e0c8a7c920aa161d26581ca3461625b9ea29c059bae02999fd388f22f). The new way is to construct a Chrome `Service` with an `executable_path` argument and pass that to the webdriver instead.

This PR retains the old functionality of reverting to the default webdriver executable path if none is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Chrome WebDriver initialization to a more modern service-based approach, improving reliability and structure.
- **Bug Fixes**
	- Enhanced the handling of the Chrome driver path while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->